### PR TITLE
NNMirror 機能強化

### DIFF
--- a/nnmirror/core.py
+++ b/nnmirror/core.py
@@ -40,13 +40,13 @@ def mirror_objects(objects=None, axis=0, direction=1, cut=False, center_toleranc
                 points = nu.get_points(obj.name(), space=om.MSpace.kObject)
 
                 for point in points:
-                    if axis == 0 and abs(point.x) <= 0.001:
+                    if axis == 0 and abs(point.x) <= center_tolerance:
                         point.x = 0
 
-                    if axis == 1 and abs(point.y) <= 0.001:
+                    if axis == 1 and abs(point.y) <= center_tolerance:
                         point.y = 0
 
-                    if axis == 2 and abs(point.z) <= 0.001:
+                    if axis == 2 and abs(point.z) <= center_tolerance:
                         point.z = 0
 
                 nu.set_points(obj.name(), points=points, space=om.MSpace.kObject)


### PR DESCRIPTION
fix #154

ミラー時のセンター許容値の指定
センターから閾値以下の距離の0セットに指定した許容値を使用するように変更
ラベルによるウェイトミラー
